### PR TITLE
Implemented redirect support as per #7.

### DIFF
--- a/src/main/java/org/terasology/assets/AssetProducer.java
+++ b/src/main/java/org/terasology/assets/AssetProducer.java
@@ -29,6 +29,8 @@ public interface AssetProducer<T extends AssetData> {
 
     Set<ResourceUrn> resolve(String urn, Name moduleContext);
 
+    ResourceUrn redirect(ResourceUrn urn);
+
     T getAssetData(ResourceUrn urn) throws IOException;
 
 }

--- a/src/test/java/org/terasology/assets/AssetTypeTest.java
+++ b/src/test/java/org/terasology/assets/AssetTypeTest.java
@@ -175,6 +175,7 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
     public void getAssetLoadsFromProducers() throws Exception {
         AssetProducer producer = mock(AssetProducer.class);
         assetType.addProducer(producer);
+        when(producer.redirect(URN)).thenReturn(URN);
         when(producer.getAssetData(URN)).thenReturn(new TextData(TEXT_VALUE));
 
         Text asset = assetType.getAsset(URN);
@@ -191,6 +192,21 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
 
         assertNull(assetType.getAsset(URN));
     }
+
+    @Test
+    public void followRedirectsGettingAssets() throws Exception {
+        AssetProducer producer = mock(AssetProducer.class);
+        ResourceUrn realUrn = new ResourceUrn("engine:real");
+        when(producer.redirect(URN)).thenReturn(realUrn);
+        when(producer.getAssetData(realUrn)).thenReturn(new TextData(TEXT_VALUE));
+        assetType.addProducer(producer);
+
+        Text asset = assetType.getAsset(URN);
+        assertNotNull(asset);
+        assertEquals(realUrn, asset.getUrn());
+        assertEquals(TEXT_VALUE, asset.getValue());
+    }
+
 
 
 }

--- a/src/test/java/org/terasology/assets/module/ModuleAssetProducerTest.java
+++ b/src/test/java/org/terasology/assets/module/ModuleAssetProducerTest.java
@@ -160,4 +160,25 @@ public class ModuleAssetProducerTest extends VirtualModuleEnvironment {
         assertNotNull(assetData);
         assertEquals("Overridden text without delta", assetData.getValue());
     }
+
+    @Test
+    public void redirects() throws Exception {
+        moduleProducer.setEnvironment(createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("redirectA"))));
+        assertEquals(new ResourceUrn("redirectA:real"), moduleProducer.redirect(new ResourceUrn("redirectA:example")));
+    }
+
+    @Test
+    public void chainedRedirects() throws Exception {
+        moduleProducer.setEnvironment(createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("redirectA"))));
+        assertEquals(new ResourceUrn("redirectA:real"), moduleProducer.redirect(new ResourceUrn("redirectA:double")));
+    }
+
+    @Test
+    public void handleRedirectResolution() throws Exception {
+        moduleProducer.setEnvironment(createEnvironment(moduleRegistry.getLatestModuleVersion(new Name("redirectA"))));
+
+        Set<ResourceUrn> results = moduleProducer.resolve("example", Name.EMPTY);
+        assertEquals(1, results.size());
+        assertTrue(results.contains(new ResourceUrn("redirectA:example")));
+    }
 }

--- a/src/test/resources/virtualModules/redirectA/assets/text/double.redirect
+++ b/src/test/resources/virtualModules/redirectA/assets/text/double.redirect
@@ -1,0 +1,1 @@
+redirectA:example

--- a/src/test/resources/virtualModules/redirectA/assets/text/example.redirect
+++ b/src/test/resources/virtualModules/redirectA/assets/text/example.redirect
@@ -1,0 +1,1 @@
+redirectA:real

--- a/src/test/resources/virtualModules/redirectA/assets/text/real.txt
+++ b/src/test/resources/virtualModules/redirectA/assets/text/real.txt
@@ -1,0 +1,1 @@
+The real thing

--- a/src/test/resources/virtualModules/redirectA/module.info
+++ b/src/test/resources/virtualModules/redirectA/module.info
@@ -1,0 +1,8 @@
+{
+    "id": "redirectA",
+    "version": "1.0.0",
+    "displayName": {
+        "en": "Test module"
+    },
+    "description" : "Contains a redirect from one asset to another"
+}


### PR DESCRIPTION
AssetTypes now check producers for redirects when getting assets.
ModuleAssetProducer loads redirect files and uses them to set up a mapping of redirects.
