### PR TITLE
Added support for asset instancing.

### DIFF
--- a/src/main/java/org/terasology/assets/AssetManager.java
+++ b/src/main/java/org/terasology/assets/AssetManager.java
@@ -50,8 +50,8 @@ public final class AssetManager {
         return assetType.loadAsset(urn, data);
     }
 
-    public <T extends Asset<U>, U extends AssetData> void dispose(T asset) {
-        AssetType<? extends Asset, AssetData> assetType = assetTypeManager.getAssetType(asset.getClass());
-        assetType.dispose(asset.getUrn());
+    public <T extends Asset<U>, U extends AssetData> T createInstance(T asset, Class<T> type) {
+        AssetType<T, U> assetType = assetTypeManager.getAssetType(type);
+        return assetType.createInstance(asset);
     }
 }

--- a/src/main/java/org/terasology/assets/AssetOwner.java
+++ b/src/main/java/org/terasology/assets/AssetOwner.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2014 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.terasology.assets;
+
+/**
+ * @author Immortius
+ */
+public abstract class AssetOwner<T extends AssetData> {
+
+    abstract void removeDisposedAsset(Asset<T> asset);
+}

--- a/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
+++ b/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionAsset.java
@@ -17,6 +17,7 @@
 package org.terasology.assets.test.stubs.extensions;
 
 import org.terasology.assets.Asset;
+import org.terasology.assets.AssetType;
 import org.terasology.naming.ResourceUrn;
 
 /**
@@ -28,6 +29,11 @@ public class ExtensionAsset extends Asset<ExtensionData> {
     public ExtensionAsset(ResourceUrn urn, ExtensionData data) {
         super(urn);
         doReload(data);
+    }
+
+    @Override
+    protected Asset<ExtensionData> doCreateInstance(ResourceUrn urn) {
+        return new ExtensionAsset(urn, new ExtensionData(value));
     }
 
     @Override

--- a/src/test/java/org/terasology/assets/test/stubs/text/Text.java
+++ b/src/test/java/org/terasology/assets/test/stubs/text/Text.java
@@ -32,6 +32,11 @@ public class Text extends Asset<TextData> {
     }
 
     @Override
+    protected Asset<TextData> doCreateInstance(ResourceUrn instanceUrn) {
+        return new Text(instanceUrn, new TextData(value));
+    }
+
+    @Override
     protected void doReload(TextData data) {
         value = data.getValue();
     }

--- a/src/test/java/org/terasology/naming/ResourceUrnTest.java
+++ b/src/test/java/org/terasology/naming/ResourceUrnTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.terasology.naming.exceptions.InvalidUrnException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -33,6 +34,8 @@ public class ResourceUrnTest {
 
     private static final String URN_STRING = TEST_MODULE + ":" + TEST_RESOURCE;
     private static final String URN_WITH_FRAGMENT_STRING = URN_STRING + "#" + TEST_FRAGMENT;
+    private static final String URN_INSTANCE_STRING = TEST_MODULE + ":" + TEST_RESOURCE + "!instance";
+    private static final String URN_FRAGMENT_INSTANCE_STRING = TEST_MODULE + ":" + TEST_RESOURCE + "#" + TEST_FRAGMENT + "!instance";
 
     @Test
     public void moduleAndResourceConstructor() {
@@ -53,10 +56,20 @@ public class ResourceUrnTest {
     }
 
     @Test
+    public void instanceConstructor() {
+        ResourceUrn urn = new ResourceUrn(TEST_MODULE, TEST_RESOURCE, true);
+        assertEquals(new Name(TEST_MODULE), urn.getModuleName());
+        assertEquals(new Name(TEST_RESOURCE), urn.getResourceName());
+        assertEquals(true, urn.isInstance());
+        assertEquals(URN_INSTANCE_STRING, urn.toString());
+    }
+
+    @Test
     public void urnStringConstructor() {
         ResourceUrn urn = new ResourceUrn(URN_STRING);
         assertEquals(new Name(TEST_MODULE), urn.getModuleName());
         assertEquals(new Name(TEST_RESOURCE), urn.getResourceName());
+        assertFalse(urn.isInstance());
         assertTrue(urn.getFragmentName().isEmpty());
         assertEquals(URN_STRING, urn.toString());
     }
@@ -68,6 +81,26 @@ public class ResourceUrnTest {
         assertEquals(new Name(TEST_RESOURCE), urn.getResourceName());
         assertEquals(new Name(TEST_FRAGMENT), urn.getFragmentName());
         assertEquals(URN_WITH_FRAGMENT_STRING, urn.toString());
+    }
+
+    @Test
+    public void urnStringContructorWithInstance() {
+        ResourceUrn urn = new ResourceUrn(URN_INSTANCE_STRING);
+        assertEquals(new Name(TEST_MODULE), urn.getModuleName());
+        assertEquals(new Name(TEST_RESOURCE), urn.getResourceName());
+        assertTrue(urn.isInstance());
+        assertTrue(urn.getFragmentName().isEmpty());
+        assertEquals(URN_INSTANCE_STRING, urn.toString());
+    }
+
+    @Test
+    public void fragmentInstanceConstructor() {
+        ResourceUrn urn = new ResourceUrn(TEST_MODULE, TEST_RESOURCE, TEST_FRAGMENT, true);
+        assertEquals(new Name(TEST_MODULE), urn.getModuleName());
+        assertEquals(new Name(TEST_RESOURCE), urn.getResourceName());
+        assertEquals(new Name(TEST_FRAGMENT), urn.getFragmentName());
+        assertEquals(true, urn.isInstance());
+        assertEquals(URN_FRAGMENT_INSTANCE_STRING, urn.toString());
     }
 
     @Test(expected = InvalidUrnException.class)
@@ -82,5 +115,28 @@ public class ResourceUrnTest {
         assertEquals(new Name(TEST_MODULE), rootUrn.getModuleName());
         assertEquals(new Name(TEST_RESOURCE), rootUrn.getResourceName());
         assertTrue(rootUrn.getFragmentName().isEmpty());
+        assertFalse(rootUrn.isInstance());
     }
+
+    @Test
+    public void getOriginResourceUrn() {
+        ResourceUrn urn = new ResourceUrn(TEST_MODULE, TEST_RESOURCE, TEST_FRAGMENT, true);
+        ResourceUrn parentUrn = urn.getParentUrn();
+        assertEquals(new Name(TEST_MODULE), parentUrn.getModuleName());
+        assertEquals(new Name(TEST_RESOURCE), parentUrn.getResourceName());
+        assertEquals(new Name(TEST_FRAGMENT), parentUrn.getFragmentName());
+        assertFalse(parentUrn.isInstance());
+    }
+
+    @Test
+    public void getInstanceResourceUrn() {
+        ResourceUrn urn = new ResourceUrn(TEST_MODULE, TEST_RESOURCE, TEST_FRAGMENT, false);
+        ResourceUrn instanceUrn = urn.getInstanceUrn();
+        assertEquals(new Name(TEST_MODULE), instanceUrn.getModuleName());
+        assertEquals(new Name(TEST_RESOURCE), instanceUrn.getResourceName());
+        assertEquals(new Name(TEST_FRAGMENT), instanceUrn.getFragmentName());
+        assertTrue(instanceUrn.isInstance());
+    }
+
+
 }


### PR DESCRIPTION
As per #15, added support for the creation of instances of assets.
This provides the ability to create copies of existing assets that can be modified independantly (e.g. get a copy of a material so that changes to its properties don't affect other users of the material).
Instances use special instance urns and are disposed with the original asset.
