### PR TITLE
Added methods for discovering what assets are available and have been loaded.

### DIFF
--- a/src/main/java/org/terasology/assets/AssetManager.java
+++ b/src/main/java/org/terasology/assets/AssetManager.java
@@ -32,6 +32,14 @@ public final class AssetManager {
         this.assetTypeManager = assetTypeManager;
     }
 
+    public <T extends Asset<U>, U extends AssetData> Set<ResourceUrn> getLoadedAssets(Class<T> type) {
+        return assetTypeManager.getAssetType(type).getLoadedAssetUrns();
+    }
+
+    public <T extends Asset<U>, U extends AssetData> Set<ResourceUrn> getAvailableAssets(Class<T> type) {
+        return assetTypeManager.getAssetType(type).getAvailableAssetUrns();
+    }
+
     public <T extends Asset<U>, U extends AssetData> Set<ResourceUrn> resolve(String urn, Class<T> type) {
         return resolve(urn, type, ContextManager.getCurrentContext());
     }

--- a/src/main/java/org/terasology/assets/AssetProducer.java
+++ b/src/main/java/org/terasology/assets/AssetProducer.java
@@ -28,6 +28,8 @@ import java.util.Set;
  */
 public interface AssetProducer<T extends AssetData> extends Closeable {
 
+    Set<ResourceUrn> getAvailableAssetUrns();
+
     Set<ResourceUrn> resolve(String urn, Name moduleContext);
 
     ResourceUrn redirect(ResourceUrn urn);
@@ -36,5 +38,6 @@ public interface AssetProducer<T extends AssetData> extends Closeable {
 
     @Override
     void close();
+
 
 }

--- a/src/main/java/org/terasology/assets/AssetType.java
+++ b/src/main/java/org/terasology/assets/AssetType.java
@@ -277,6 +277,18 @@ public final class AssetType<T extends Asset<U>, U extends AssetData> extends As
         return loadedAssets.containsKey(urn);
     }
 
+    public Set<ResourceUrn> getLoadedAssetUrns() {
+        return ImmutableSet.copyOf(loadedAssets.keySet());
+    }
+
+    public Set<ResourceUrn> getAvailableAssetUrns() {
+        Set<ResourceUrn> availableAssets = Sets.newLinkedHashSet(getLoadedAssetUrns());
+        for (AssetProducer<U> producer : producers) {
+            availableAssets.addAll(producer.getAvailableAssetUrns());
+        }
+        return availableAssets;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {

--- a/src/main/java/org/terasology/assets/module/ModuleAssetProducer.java
+++ b/src/main/java/org/terasology/assets/module/ModuleAssetProducer.java
@@ -134,6 +134,11 @@ public class ModuleAssetProducer<U extends AssetData> implements AssetProducer<U
     }
 
     @Override
+    public Set<ResourceUrn> getAvailableAssetUrns() {
+        return ImmutableSet.copyOf(unloadedAssetLookup.keySet());
+    }
+
+    @Override
     public Set<ResourceUrn> resolve(String urn, Name moduleContext) {
         Preconditions.checkState(moduleEnvironment != null, "Module environment not set");
 

--- a/src/main/java/org/terasology/assets/module/UnloadedAsset.java
+++ b/src/main/java/org/terasology/assets/module/UnloadedAsset.java
@@ -26,7 +26,6 @@ import org.terasology.naming.Name;
 import org.terasology.naming.ResourceUrn;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;

--- a/src/test/java/org/terasology/assets/AssetTypeTest.java
+++ b/src/test/java/org/terasology/assets/AssetTypeTest.java
@@ -67,8 +67,10 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         TextData data = new TextData(TEXT_VALUE);
         Text text = new Text(URN, data);
 
+        assertFalse(assetType.isLoaded(URN));
         Text createdText = assetType.loadAsset(URN, data);
         assertEquals(text, createdText);
+        assertTrue(assetType.isLoaded(URN));
     }
 
     @Test
@@ -184,6 +186,7 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         assertNotNull(asset);
         assertEquals(URN, asset.getUrn());
         assertEquals(TEXT_VALUE, asset.getValue());
+        assertTrue(assetType.isLoaded(URN));
     }
 
     @Test
@@ -194,6 +197,7 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         when(producer.getAssetData(URN)).thenThrow(new IOException());
 
         assertNull(assetType.getAsset(URN));
+        assertFalse(assetType.isLoaded(URN));
     }
 
     @Test
@@ -360,6 +364,33 @@ public class AssetTypeTest extends VirtualModuleEnvironment {
         Set<ResourceUrn> results = assetType.resolve(URN.getResourceName().toString() + ResourceUrn.INSTANCE_INDICATOR);
         assertEquals(1, results.size());
         assertTrue(results.contains(URN.getInstanceUrn()));
+    }
+
+    @Test
+    public void getLoaded() throws Exception {
+        TextData data = new TextData(TEXT_VALUE);
+
+        assertTrue(assetType.getLoadedAssetUrns().isEmpty());
+        assetType.loadAsset(URN, data);
+        assertEquals(ImmutableSet.of(URN), assetType.getLoadedAssetUrns());
+    }
+
+    @Test
+    public void getAvailableIncludesLoaded() {
+        TextData data = new TextData(TEXT_VALUE);
+
+        assertTrue(assetType.getAvailableAssetUrns().isEmpty());
+        assetType.loadAsset(URN, data);
+        assertEquals(ImmutableSet.of(URN), assetType.getAvailableAssetUrns());
+    }
+
+    @Test
+    public void getAvailableIncludesFromProducer() {
+        AssetProducer producer = mock(AssetProducer.class);
+        when(producer.getAvailableAssetUrns()).thenReturn(ImmutableSet.of(URN));
+        assetType.addProducer(producer);
+
+        assertEquals(ImmutableSet.of(URN), assetType.getAvailableAssetUrns());
     }
 
 }

--- a/src/test/java/org/terasology/assets/test/stubs/book/BookFragmentProducer.java
+++ b/src/test/java/org/terasology/assets/test/stubs/book/BookFragmentProducer.java
@@ -21,6 +21,9 @@ import org.terasology.assets.AssetManager;
 import org.terasology.assets.test.stubs.text.TextData;
 import org.terasology.naming.ResourceUrn;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * @author Immortius
  */
@@ -41,5 +44,10 @@ public class BookFragmentProducer extends AbstractFragmentProducer<TextData, Boo
         } catch (NumberFormatException e) {
             return null;
         }
+    }
+
+    @Override
+    public Set<ResourceUrn> getAvailableAssetUrns() {
+        return Collections.emptySet();
     }
 }

--- a/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionProducer.java
+++ b/src/test/java/org/terasology/assets/test/stubs/extensions/ExtensionProducer.java
@@ -37,6 +37,11 @@ public class ExtensionProducer implements AssetProducer<TextData> {
     }
 
     @Override
+    public Set<ResourceUrn> getAvailableAssetUrns() {
+        return Collections.emptySet();
+    }
+
+    @Override
     public Set<ResourceUrn> resolve(String urn, Name moduleContext) {
         return Collections.emptySet();
     }


### PR DESCRIPTION
Addressing issue #23. AssetProducers may now provide a list of assets urns they can produce - this is optional, but is implemented for ModuleAssetProducer.
